### PR TITLE
The rubyblue theme, I think, has too dark a cursor

### DIFF
--- a/react/css/react.scss
+++ b/react/css/react.scss
@@ -637,6 +637,11 @@ div.CodeMirror-linenumber {
   visibility: hidden;
 }
 
+/* Fix rubyblue theme cursor color */
+.CodeMirror.cm-s-rubyblue div.CodeMirror-cursor {
+  border-left: 1px solid white;
+}
+
 small code,
 li code,
 p code {


### PR DESCRIPTION
... on a dark background. This switches to a white cursor.
