### PR TITLE
fix a broken navigation link on the blog

### DIFF
--- a/_includes/blog_post.html
+++ b/_includes/blog_post.html
@@ -4,7 +4,7 @@
 {% if include.isPermalink %}
   {{ page.title }}
 {% else %}
-  <a href="/react{{ page.url }}">{{ page.title }}</a>
+  <a href="{{ page.url }}">{{ page.title }}</a>
 {% endif %}
 </h1>
 


### PR DESCRIPTION
The links on blog article titles are currently broken.
