### PR TITLE
Link should be to /tutorials

### DIFF
--- a/installation/index.html
+++ b/installation/index.html
@@ -259,7 +259,7 @@ called react_lib.</p>
 
 <h2 id="next-steps">Next Steps</h2>
 
-<p>Check out <a href="/tutorial">the tutorial</a> to learn more.</p>
+<p>Check out <a href="/tutorials">the tutorial</a> to learn more.</p>
 
 <p>Good luck, and welcome!</p>
 


### PR DESCRIPTION
This fixes a broken link on installation page
