### PR TITLE
show_text was unused method in example

### DIFF
--- a/start/components/index.html
+++ b/start/components/index.html
@@ -428,7 +428,7 @@ class StateExample < Hyperloop::Component
     show_button
     DIV do
       show_input
-      H1 { "#{state.field_value}" }
+      show_text
     end if state.show_field
   end
 


### PR DESCRIPTION
was a little confusing at first
![hyperloop 2017-05-09 17-51-28](https://cloud.githubusercontent.com/assets/6732638/25874363/33e81d50-34e0-11e7-80ba-dc3928051db5.png)
